### PR TITLE
BedrockActionTranslator: Fix occasional death stall

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockActionTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockActionTranslator.java
@@ -68,6 +68,8 @@ public class BedrockActionTranslator extends PacketTranslator<PlayerActionPacket
                 eventPacket.setType(EntityEventType.RESPAWN);
                 eventPacket.setData(0);
                 session.sendUpstreamPacket(eventPacket);
+                // Resend attributes or else in rare cases the user can think they're not dead when they are, upon joining the server
+                entity.updateBedrockAttributes(session);
                 break;
             case START_SWIMMING:
                 ClientPlayerStatePacket startSwimPacket = new ClientPlayerStatePacket((int) entity.getEntityId(), PlayerState.START_SPRINTING);


### PR DESCRIPTION
Usually this happened when joining from another dimension after the player exited to the main menu on the death screen. The player would not realize that they are dead.