### PR TITLE
Fix regressions from 1.16.100 (#1558)

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/ItemFrameEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/ItemFrameEntity.java
@@ -98,14 +98,12 @@ public class ItemFrameEntity extends Entity {
             ItemEntry itemEntry = ItemRegistry.getItem((ItemStack) entityMetadata.getValue());
             NbtMapBuilder builder = NbtMap.builder();
 
-            String blockName = ItemRegistry.getBedrockIdentifier(itemEntry);
-
             builder.putByte("Count", (byte) itemData.getCount());
             if (itemData.getTag() != null) {
                 builder.put("tag", itemData.getTag().toBuilder().build());
             }
             builder.putShort("Damage", itemData.getDamage());
-            builder.putString("Name", blockName);
+            builder.putString("Name", itemEntry.getBedrockIdentifier());
             NbtMapBuilder tag = getDefaultTag().toBuilder();
             tag.put("Item", builder.build());
             tag.putFloat("ItemDropChance", 1.0f);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemEntry.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemEntry.java
@@ -34,9 +34,10 @@ import lombok.ToString;
 @ToString
 public class ItemEntry {
 
-    public static ItemEntry AIR = new ItemEntry("minecraft:air", 0, 0, 0, false);
+    public static ItemEntry AIR = new ItemEntry("minecraft:air", "minecraft:air", 0, 0, 0, false);
 
     private final String javaIdentifier;
+    private final String bedrockIdentifier;
     private final int javaId;
     private final int bedrockId;
     private final int bedrockData;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ItemTranslator.java
@@ -34,16 +34,13 @@ import com.nukkitx.nbt.NbtType;
 import com.nukkitx.protocol.bedrock.data.inventory.ItemData;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.ItemRemapper;
+import org.geysermc.connector.network.translators.chat.MessageTranslator;
 import org.geysermc.connector.network.translators.world.block.BlockTranslator;
 import org.geysermc.connector.utils.FileUtils;
 import org.geysermc.connector.utils.LanguageUtils;
-import org.geysermc.connector.network.translators.chat.MessageTranslator;
 import org.reflections.Reflections;
 
 import java.util.*;

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/ToolItemEntry.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/ToolItemEntry.java
@@ -32,8 +32,8 @@ public class ToolItemEntry extends ItemEntry {
     private final String toolType;
     private final String toolTier;
 
-    public ToolItemEntry(String javaIdentifier, int javaId, int bedrockId, int bedrockData, String toolType, String toolTier, boolean isBlock) {
-        super(javaIdentifier, javaId, bedrockId, bedrockData, isBlock);
+    public ToolItemEntry(String javaIdentifier, String bedrockIdentifier, int javaId, int bedrockId, int bedrockData, String toolType, String toolTier, boolean isBlock) {
+        super(javaIdentifier, bedrockIdentifier, javaId, bedrockId, bedrockData, isBlock);
         this.toolType = toolType;
         this.toolTier = toolTier;
     }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/CompassTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/CompassTranslator.java
@@ -53,7 +53,7 @@ public class CompassTranslator extends ItemTranslator {
         Tag lodestoneTag = itemStack.getNbt().get("LodestoneTracked");
         if (lodestoneTag instanceof ByteTag) {
             // Get the fake lodestonecompass entry
-            itemEntry = ItemRegistry.getItemEntry("minecraft:lodestonecompass");
+            itemEntry = ItemRegistry.getItemEntry("minecraft:lodestone_compass");
 
             // Get the loadstone pos
             CompoundTag loadstonePos = itemStack.getNbt().get("LodestonePos");
@@ -83,7 +83,7 @@ public class CompassTranslator extends ItemTranslator {
     @Override
     public ItemStack translateToJava(ItemData itemData, ItemEntry itemEntry) {
         boolean isLoadstone = false;
-        if (itemEntry.getJavaIdentifier().equals("minecraft:lodestonecompass")) {
+        if (itemEntry.getBedrockIdentifier().equals("minecraft:lodestone_compass")) {
             // Revert the entry back to the compass
             itemEntry = ItemRegistry.getItemEntry("minecraft:compass");
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/CrossbowTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/CrossbowTranslator.java
@@ -45,15 +45,15 @@ public class CrossbowTranslator extends NbtItemStackTranslator {
             if (!chargedProjectiles.getValue().isEmpty()) {
                 CompoundTag projectile = (CompoundTag) chargedProjectiles.getValue().get(0);
 
-                ItemEntry entry = ItemRegistry.getItemEntry((String) projectile.get("id").getValue());
-                if (entry == null) return;
+                ItemEntry projectileEntry = ItemRegistry.getItemEntry((String) projectile.get("id").getValue());
+                if (projectileEntry == null) return;
                 CompoundTag tag = projectile.get("tag");
                 ItemStack itemStack = new ItemStack(itemEntry.getJavaId(), (byte) projectile.get("Count").getValue(), tag);
                 ItemData itemData = ItemTranslator.translateToBedrock(session, itemStack);
 
                 CompoundTag newProjectile = new CompoundTag("chargedItem");
                 newProjectile.put(new ByteTag("Count", (byte) itemData.getCount()));
-                newProjectile.put(new StringTag("Name", ItemRegistry.getBedrockIdentifier(entry)));
+                newProjectile.put(new StringTag("Name", projectileEntry.getBedrockIdentifier()));
 
                 newProjectile.put(new ShortTag("Damage", itemData.getDamage()));
 

--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/ShulkerBoxItemTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/nbt/ShulkerBoxItemTranslator.java
@@ -50,9 +50,8 @@ public class ShulkerBoxItemTranslator extends NbtItemStackTranslator {
             boxItemTag.put(new ByteTag("WasPickedUp", (byte) 0)); // ???
 
             ItemEntry boxItemEntry = ItemRegistry.getItemEntry(((StringTag) itemData.get("id")).getValue());
-            String blockName = ItemRegistry.getBedrockIdentifier(boxItemEntry);
 
-            boxItemTag.put(new StringTag("Name", blockName));
+            boxItemTag.put(new StringTag("Name", boxItemEntry.getBedrockIdentifier()));
             boxItemTag.put(new ShortTag("Damage", (short) boxItemEntry.getBedrockData()));
             boxItemTag.put(new ByteTag("Count", ((ByteTag) itemData.get("Count")).getValue()));
             if (itemData.contains("tag")) {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaTradeListTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaTradeListTranslator.java
@@ -139,7 +139,7 @@ public class JavaTradeListTranslator extends PacketTranslator<ServerTradeListPac
         NbtMapBuilder builder = NbtMap.builder();
         builder.putByte("Count", (byte) (Math.max(itemData.getCount() + specialPrice, 1)));
         builder.putShort("Damage", itemData.getDamage());
-        builder.putShort("id", (short) itemEntry.getBedrockId());
+        builder.putString("Name", itemEntry.getBedrockIdentifier());
         if (itemData.getTag() != null) {
             NbtMap tag = itemData.getTag().toBuilder().build();
             builder.put("tag", tag);


### PR DESCRIPTION
* Fix regressions from 1.16.100

- Update mappings to fix recipe regressions and item differences
- Villager trading NBT now prefers the String identifier and not the integer ID

* Fix lodestone compass breaking