### PR TITLE
Fix NPE when link entity not found and use non-deprecated constructor…

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/player/PlayerEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/player/PlayerEntity.java
@@ -103,7 +103,10 @@ public class PlayerEntity extends LivingEntity {
 
         long linkedEntityId = session.getEntityCache().getCachedPlayerEntityLink(entityId);
         if (linkedEntityId != -1) {
-            addPlayerPacket.getEntityLinks().add(new EntityLinkData(session.getEntityCache().getEntityByJavaId(linkedEntityId).getGeyserId(), geyserId, EntityLinkData.Type.RIDER, false));
+            Entity linkedEntity = session.getEntityCache().getEntityByJavaId(linkedEntityId);
+            if (linkedEntity != null) {
+                addPlayerPacket.getEntityLinks().add(new EntityLinkData(linkedEntity.getGeyserId(), geyserId, EntityLinkData.Type.RIDER, false, false));
+            }
         }
 
         valid = true;


### PR DESCRIPTION
… (#1706)

* Fix NPE when link entity not found and use non-deprecated constructor

* Extract method call to variable

* Update PlayerEntity.java

* Fix indentation